### PR TITLE
Big ints / long floats optimization

### DIFF
--- a/extras/data-tests/src/main.rs
+++ b/extras/data-tests/src/main.rs
@@ -30,10 +30,10 @@ impl TestCase {
             dbg!(self);
             eprintln!("Failed to parse as f32: {:?}", self.string);
         }
-        let (value, rest) = r.unwrap();
-        if !rest.is_empty() || value != expected {
-            if !rest.is_empty() {
-                eprintln!("Expected empty string remainder, got: {:?}", rest);
+        let (value, len) = r.unwrap();
+        if len != s.len() || value != expected {
+            if len != s.len() {
+                eprintln!("Expected empty string remainder, got: {:?}", s.len() - len);
             }
             if value != expected {
                 eprintln!("Expected output {}, got {}", expected, value);

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -33,51 +33,6 @@ impl Decimal {
     }
 
     #[inline]
-    pub fn to_truncated_mantissa(&self) -> u64 {
-        let mut mantissa = 0;
-        if cfg!(target_endian = "big") {
-            for i in 0..Self::MAX_DIGITS_WITHOUT_OVERFLOW {
-                mantissa = mantissa * 10 + self.digits[i] as u64;
-            }
-        } else {
-            let mut val = self.digits.read_u64();
-            val = val.wrapping_mul(2561) >> 8;
-            val = (val & 0x00FF00FF00FF00FF).wrapping_mul(6553601) >> 16;
-            mantissa =
-                (((val & 0x0000FFFF0000FFFF).wrapping_mul(42949672960001) >> 32) as u32) as u64;
-            let mut val = self.digits[8..].read_u64();
-            val = val.wrapping_mul(2561) >> 8;
-            val = (val & 0x00FF00FF00FF00FF).wrapping_mul(6553601) >> 16;
-            let eight_digits_value =
-                (((val & 0x0000FFFF0000FFFF).wrapping_mul(42949672960001) >> 32) as u32) as u64;
-            mantissa = 100000000 * mantissa + eight_digits_value;
-            for i in 16..Self::MAX_DIGITS_WITHOUT_OVERFLOW {
-                mantissa = mantissa * 10 + self.digits[i] as u64;
-            }
-            if false {
-                let mut val = self.digits.read_u64();
-                val = val * 2561 >> 8;
-                val = (val & 0x00FF00FF00FF00FF) * 6553601 >> 16;
-                mantissa = (val & 0x0000FFFF0000FFFF) * 42949672960001 >> 32;
-                let mut val = self.digits[8..].read_u64();
-                val = val * 2561 >> 8;
-                val = (val & 0x00FF00FF00FF00FF) * 6553601 >> 16;
-                let eight_digits_value = (val & 0x0000FFFF0000FFFF) * 42949672960001 >> 32;
-                mantissa = 100000000 * mantissa + eight_digits_value;
-                for i in 16..Self::MAX_DIGITS_WITHOUT_OVERFLOW {
-                    mantissa = mantissa * 10 + self.digits[i] as u64;
-                }
-            }
-        }
-        mantissa
-    }
-
-    #[inline]
-    pub fn to_truncated_exponent(&self) -> i32 {
-        self.decimal_point - Self::MAX_DIGITS_WITHOUT_OVERFLOW as i32
-    }
-
-    #[inline]
     pub fn try_add_digit(&mut self, digit: u8) {
         if self.num_digits < Self::MAX_DIGITS {
             self.digits[self.num_digits] = digit;

--- a/src/number.rs
+++ b/src/number.rs
@@ -2,11 +2,14 @@ use crate::common::{is_8digits_le, AsciiStr, ByteSlice};
 use crate::float::Float;
 use crate::format::FloatFormat;
 
+const MIN_19DIGIT_INT: u64 = 100_0000_0000_0000_0000;
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct Number {
     pub exponent: i64,
     pub mantissa: u64,
     pub negative: bool,
+    pub many_digits: bool,
 }
 
 impl Number {
@@ -15,6 +18,7 @@ impl Number {
         F::MIN_EXPONENT_FAST_PATH <= self.exponent
             && self.exponent <= F::MAX_EXPONENT_FAST_PATH
             && self.mantissa <= F::MAX_MANTISSA_FAST_PATH
+            && !self.many_digits
     }
 
     #[inline]
@@ -54,6 +58,15 @@ fn try_parse_digits(s: &mut AsciiStr<'_>, x: &mut u64) {
     s.parse_digits(|digit| {
         *x = x.wrapping_mul(10).wrapping_add(digit as _); // overflows to be handled later
     });
+}
+
+#[inline]
+fn try_parse_19digits(s: &mut AsciiStr<'_>, x: &mut u64) {
+    while *x < MIN_19DIGIT_INT && !s.is_empty() && s.first().is_ascii_digit() {
+        let digit = s.first() - b'0';
+        *x = (*x * 10) + digit as u64; // no overflows here
+        s.step();
+    }
 }
 
 #[inline]
@@ -135,6 +148,7 @@ pub fn parse_number(s: &[u8], fmt: FloatFormat) -> Option<(Number, usize)> {
     // handle dot with the following digits
     let mut n_after_dot = 0;
     let mut exponent = 0i64;
+    let int_end = s;
     if s.check_first(b'.') {
         s.step();
         let before = s;
@@ -150,15 +164,18 @@ pub fn parse_number(s: &[u8], fmt: FloatFormat) -> Option<(Number, usize)> {
     }
 
     // handle scientific format
+    let mut exp_number = 0i64;
     if fmt.scientific {
         if s.check_first_either(b'e', b'E') {
-            parse_scientific(&mut s, &mut exponent, fmt.fixed)?;
+            parse_scientific(&mut s, &mut exp_number, fmt.fixed)?;
+            exponent += exp_number;
         } else if !fmt.fixed {
             return None; // error: scientific and not fixed
         }
     }
 
     // handle uncommon case with many digits
+    let mut many_digits = false;
     n_digits -= 19;
     if n_digits > 0 {
         let mut p = digits_start;
@@ -167,7 +184,20 @@ pub fn parse_number(s: &[u8], fmt: FloatFormat) -> Option<(Number, usize)> {
             p.step();
         }
         if n_digits > 0 {
-            mantissa = u64::MAX;
+            // at this point we have more than 19 significant digits, let's try again
+            many_digits = true;
+            mantissa = 0u64;
+            let mut s = digits_start;
+            try_parse_19digits(&mut s, &mut mantissa);
+            exponent = if mantissa >= MIN_19DIGIT_INT {
+                int_end.offset_from(&s) // big int
+            } else {
+                s.step(); // fractional component, skip the '.'
+                let before = s;
+                try_parse_19digits(&mut s, &mut mantissa);
+                -s.offset_from(&before)
+            } as i64;
+            exponent += exp_number; // add back the explicit part
         }
     }
 
@@ -175,6 +205,7 @@ pub fn parse_number(s: &[u8], fmt: FloatFormat) -> Option<(Number, usize)> {
         exponent,
         mantissa,
         negative,
+        many_digits,
     };
     Some((number, s.offset_from(&start) as usize))
 }

--- a/src/simple.rs
+++ b/src/simple.rs
@@ -1,4 +1,3 @@
-use crate::binary::compute_float_from_exp_mantissa;
 use crate::common::AdjustedMantissa;
 use crate::decimal::Decimal;
 use crate::float::Float;
@@ -6,15 +5,7 @@ use crate::float::Float;
 #[inline]
 pub fn parse_long_mantissa<F: Float>(s: &[u8]) -> AdjustedMantissa {
     let mut d = Decimal::parse(s);
-    let mantissa = d.to_truncated_mantissa();
-    let exponent = d.to_truncated_exponent() as i64;
-    let am1 = compute_float_from_exp_mantissa::<F>(exponent, mantissa);
-    let am2 = compute_float_from_exp_mantissa::<F>(exponent, mantissa + 1);
-    if am1 == am2 && am1.power2 >= 0 {
-        am1
-    } else {
-        compute_float_from_decimal::<F>(&mut d)
-    }
+    compute_float_from_decimal::<F>(&mut d)
 }
 
 #[inline]


### PR DESCRIPTION
@lemire

The speedups are not related to this change, without them there's around [+2%; +3%] slowdown, but they seem to compensate for the extra added logic. I'm particularly happy that mesh.txt benchmarks (that are super sensitive to instruction count) are not hurt in the end.

We also seem to have made it past lexical in the big_ints case which is nice.

Benchmarks:

### `big_ints`

```
fast_float (before) 	175.31 ns
fast_float (after)	83.38 ns	(-52.4%)
lexical_core     	94.86 ns
from_str        	452.05 ns
```

### `uniform`

```
fast_float (before) 	19.98 ns
fast_float (after)   	20.30 ns	(+1.1%)
lexical_core     	53.85 ns
from_str        	101.32 ns
```

### `canada.txt`

```
fast_float (before)	22.29 ns
fast_float (after)  	22.05 ns	(-1.1%)
lexical_core     	64.61 ns
from_str        	173.28 ns
```

### `mesh.txt`

```
fast_float (before) 	10.70 ns
fast_float (after)  	10.71 ns	(+0.0%)
lexical_core     	22.98 ns
from_str         	22.52 ns
```