### PR TITLE
remove unsafe from float.rs at very small performance cost

### DIFF
--- a/src/float.rs
+++ b/src/float.rs
@@ -70,8 +70,20 @@ impl Float for f32 {
     #[inline]
     #[allow(clippy::use_self)]
     fn pow10_fast_path(exponent: usize) -> Self {
-        const TABLE: [f32; 11] = [1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9, 1e10];
-        unsafe { *TABLE.get_unchecked(exponent) }
+        match exponent {
+            0 => 1e0,
+            1 => 1e1,
+            2 => 1e2,
+            3 => 1e3,
+            4 => 1e4,
+            5 => 1e5,
+            6 => 1e6,
+            7 => 1e7,
+            8 => 1e8,
+            9 => 1e9,
+            10 => 1e10,
+            _ => unreachable!(),
+        }
     }
 }
 


### PR DESCRIPTION
OLD:

min/median/max

ns/float: 22.29/23.64/28.55
Mfloat/s: 44.86/42.31/35.03
MB/s: 781.57/737.14/610.28

NEW:
ns/float: 22.9/24.94/30.69
Mfloat/s: 43.67/40.10/32.59
MB/s: 760/87/698.71/567.77

I'm going to continue working on this to try and improve it as much as possible.