### PR TITLE
Update `try_add_digit` for more efficient ASM generation.

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -56,8 +56,8 @@ impl Decimal {
     pub fn try_add_digit(&mut self, digit: u8) {
         if self.num_digits < Self::MAX_DIGITS {
             self.digits[self.num_digits] = digit;
+            self.num_digits += 1;
         }
-        self.num_digits += 1;
     }
 
     #[inline]


### PR DESCRIPTION
This generates more efficient assembly, and also makes justifying `trim` easier to rationalize from a cursory glance at the code.

**Original**

```asm
example::Decimal::try_add_digit:
        mov     rax, qword ptr [rdi]
        cmp     rax, 767
        ja      .LBB0_2
        mov     byte ptr [rdi + rax + 14], sil
        mov     rax, qword ptr [rdi]
.LBB0_2:
        add     rax, 1
        mov     qword ptr [rdi], rax
        ret
```

**New**

```asm
example::Decimal::try_add_digit:
        mov     rax, qword ptr [rdi]
        cmp     rax, 767
        ja      .LBB0_2
        mov     byte ptr [rdi + rax + 14], sil
        add     qword ptr [rdi], 1
.LBB0_2:
        ret
```